### PR TITLE
chore: improve configuration and documentation

### DIFF
--- a/actual/README.md
+++ b/actual/README.md
@@ -8,10 +8,9 @@ Create a `.env` file in this directory:
 
 ```env
 # Domain configuration
-DOMAIN=actual.yourdomain.com
+ACTUAL_DOMAIN=actual.yourdomain.com
 
 # Server configuration
-ACTUAL_PORT=5006
 ACTUAL_SYNC_KEY=your_secure_sync_key_here
 
 # Optional: Custom data directory
@@ -30,10 +29,14 @@ docker compose up -d
 ./generate_compose.py actual
 ```
 
-## Notes
+## Updates
+This container will have its image automatically updated via [watchtower](../watchtower/).
 
+## Backups
+Data for Actual is stored at the configured `ACTUAL_DATA_DIR`, and should be backed up regularly using standard filesystem backup tools.
+
+## Notes
 - The server will be available at `https://actual.yourdomain.com`
 - Data is persisted in the configured data directory
 - Make sure to save your sync key - you'll need it to connect clients to your server
 - The web interface is served directly from the server
-- Backup your data directory regularly!

--- a/actual/docker-compose.yml
+++ b/actual/docker-compose.yml
@@ -27,3 +27,4 @@ services:
 networks:
   proxy:
     external: true
+    name: proxy

--- a/foundryvtt/README.md
+++ b/foundryvtt/README.md
@@ -41,10 +41,10 @@ docker-compose up -d
 3. Place this file at `$DATA_DIRECTORY/Foundry/data/Config`. This is related to the volume mount specified in `docker-compose.yml`.
 
 ### Native Audio and Video Support
-Edit `${DATA_DIRECTORY/Foundry/data/Config/options.json` and change `proxySSL: false` to `proxySSL: true`
+Edit `${DATA_DIRECTORY}/Foundry/data/Config/options.json` and change `proxySSL: false` to `proxySSL: true`
 
 ## Updates
-This container will have its image automatically updated via [watchtower](https://ryanliu6/focus/watchtower).
+This container will have its image automatically updated via [watchtower](../watchtower/).
 
 ## Backups
 Data for Foundry is stored locally at `$DATA_DIRECTORY/Foundry/data`, and can be backed up via cronjob with the following:

--- a/foundryvtt/docker-compose.yml
+++ b/foundryvtt/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - FOUNDRY_AWS_CONFIG=/data/Config/s3.json
       - FOUNDRY_PROXY_PORT=30000
       - FOUNDRY_PROXY_SSL=true
-      - TIMEZONE=CA
+      - TIMEZONE=America/Vancouver
       - CONTAINER_PATCH_URLS=https://gist.githubusercontent.com/yddlef/df54ee1bbca93095a71d75cd15e216eb/raw/plutonium.sh
     labels:
       - "traefik.enable=true"

--- a/jellyfin/README.md
+++ b/jellyfin/README.md
@@ -12,11 +12,11 @@ JELLYFIN_DOMAIN=<jellyfin domain>
 DATA_DIRECTORY=<your_directory>
 ```
 
-2. Configure the media directories to mount so that the container has access to it. By default, Jellyfin will mount `$DATA_DIRECTORY/Media/movies` to `/data/movies` to the container. This behaviour can be configured with the following in `docker-compose.yml`.
+2. Configure the media directories to mount so that the container has access to it. This behaviour can be configured with the following in `docker-compose.yml`.
 
 ```yaml
-    - ${DATA_DIRECTORY}/Media/config/jellyfin:/config
-    - ${DATA_DIRECTORY}/Media/movies:/data/movies
+    - ${DATA_DIRECTORY}/Config/jellyfin:/config
+    - ${DATA_DIRECTORY}/Media/.same:/data/movies
 ```
 
 3. Run it!
@@ -25,13 +25,13 @@ docker compose up -d
 ```
 
 ## Updates
-This container will have its image automatically updated via [watchtower](https://ryanliu6/focus/watchtower).
+This container will have its image automatically updated via [watchtower](../watchtower/).
 
 ## Backups
 There's not much to backup for Jellyfin, since the data that will be backed up will be the actual media to be shared.
 
-If you so wish, config can be backed up and preserved; its stored locally at `${DATA_DIRECTORY}/Media/config/jellyfin`, and can be backed up via cronjob with the following:
+If you so wish, config can be backed up and preserved; it's stored locally at `${DATA_DIRECTORY}/Config/jellyfin`, and can be backed up via cronjob with the following:
 
-```
-0 0 * * 1 sudo tar -cf $DATA_DIRECTORY/Backups/jellyfin/`date+%F`.tar $DATA_DIRECTORY/Config/jellyfin
+```bash
+0 0 * * 1 sudo tar -cf $DATA_DIRECTORY/Backups/jellyfin/`date +\%F`.tar $DATA_DIRECTORY/Config/jellyfin
 ```

--- a/jellyfin/docker-compose.yml
+++ b/jellyfin/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=America/Vancouver
       - JELLYFIN_PublishedServerUrl=${JELLYFIN_DOMAIN}
     labels:
       - "traefik.enable=true"

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -10,17 +10,16 @@ Docker Image is from traefik, found [here](https://hub.docker.com/r/traefik/trae
 > This step is entirely optional. To skip this step, edit docker-compose.yml and remove the line
 > at the bottom that specifies the password
 
-2. Update `traefik.yml` with your correct contact information (Email)
-
-3. Create an `.env` file with:
+2. Create an `.env` file with:
 ```ini
 DOMAIN=traefik.domain
 TLD=com
+ACME_EMAIL=your.email@example.com
 TRAEFIK_USER=admin
 TRAEFIK_PASSWORD_HASH=<password from generate_password.sh>
 ```
 
-4. Add DNS Provider specific configuration to `.env` and `docker-compose.yml`. In my case, I'm using CloudFlare, and so my file will have the following:
+3. Add DNS Provider specific configuration to `.env` and `docker-compose.yml`. In my case, I'm using CloudFlare, and so my file will have the following:
 ```ini
 CLOUDFLARE_DNS_API_TOKEN=<some token>
 ```
@@ -32,7 +31,7 @@ CLOUDFLARE_DNS_API_TOKEN=<some token>
 
 Other DNS Providers will have differing configuration. You can find providers [here](https://doc.traefik.io/traefik/https/acme/#providers) and additional configuration [here](https://go-acme.github.io/lego/dns/).
 
-5. Configure the following directories, as this guide assumes that Focus is cloned to `$HOME/dev/focus`, as that is my own personal preference. This behaviour can be configured with the following in `docker-compose.yml`.
+4. Configure the following directories, as this guide assumes that Focus is cloned to `$HOME/dev/focus`, as that is my own personal preference. This behaviour can be configured with the following in `docker-compose.yml`.
 
 ```yaml
   - ${HOME}/dev/focus/traefik/traefik.yml:/traefik.yml:ro
@@ -40,7 +39,7 @@ Other DNS Providers will have differing configuration. You can find providers [h
   - ${HOME}/dev/focus/traefik/letsencrypt:/letsencrypt
 ```
 
-6. Run it!
+5. Run it!
 ```bash
 docker-compose up -d
 ```
@@ -49,7 +48,7 @@ docker-compose up -d
 > This assumes that `focus` is checked out at `$HOME/dev/focus`!
 
 ## Updates
-This container will have its image automatically updated via [watchtower](https://ryanliu6/focus/watchtower).
+This container will have its image automatically updated via [watchtower](../watchtower/).
 
 ## Backups
 N/A

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ${HOME}/dev/focus/traefik/rules:/rules:ro
       - ${HOME}/dev/focus/traefik/letsencrypt:/letsencrypt
     environment:
+      - ACME_EMAIL=${ACME_EMAIL}
       - CLOUDFLARE_DNS_API_TOKEN=${CLOUDFLARE_DNS_API_TOKEN}
     labels:
       - "traefik.enable=true"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -19,7 +19,7 @@ providers:
 certificatesResolvers:
   certchallenge:
     acme:
-      email: "example@example.com"
+      email: ${ACME_EMAIL}
       storage: ./letsencrypt/acme.json
       dnsChallenge:
         provider: cloudflare

--- a/transmission/README.md
+++ b/transmission/README.md
@@ -4,7 +4,7 @@
 Docker Image is from Linuxserver, found [here](https://hub.docker.com/r/linuxserver/transmission).
 
 ## Setup
-1. Create an `.env` file with
+1. Create an `.env` file with:
 ```ini
 TRANSMISSION_USERNAME=<your_username>
 TRANSMISSION_PASSWORD=<your_password>
@@ -48,7 +48,7 @@ docker-compose up -d
 ```
 
 ## Updates
-This container will have its image automatically updated via [watchtower](https://ryanliu6/focus/watchtower).
+This container will have its image automatically updated via [watchtower](../watchtower/).
 
 ## Backup
 Data for Transmission is stored locally at `${DATA_DIRECTORY}/Config/transmission`, and can be backed up via cronjob with the following:


### PR DESCRIPTION
## Summary
- Convert traefik email from hardcoded to environment variable (ACME_EMAIL)
- Standardize timezones across services to America/Vancouver
- Add explicit network name to actual service for clarity
- Fix broken watchtower documentation links across all READMEs
- Update Jellyfin README to reflect actual docker-compose paths
- Add Updates and Backups sections to Actual README for consistency
- Fix typo in FoundryVTT README (missing closing bracket in path variable)
- Add missing colon to Transmission README setup instruction
- Update README step numbering in Traefik documentation