### PR TITLE
Fixing jotty ssl3 issues

### DIFF
--- a/services/jotty/docker-compose.yml
+++ b/services/jotty/docker-compose.yml
@@ -20,9 +20,8 @@ services:
       - ${NEXUS_DATA_DIRECTORY}/jotty/cache:/app/.next/cache:rw
     environment:
       - NODE_ENV=production
-      - TZ=${TZ}
-      - NEXTAUTH_URL=https://jotty.${NEXUS_DOMAIN}
-      - NEXTAUTH_URL_INTERNAL=http://127.0.0.1:3000
+      - HTTPS=true
+      - APP_URL=https://jotty.${NEXUS_DOMAIN}
     healthcheck:
       test:
         [

--- a/services/jotty/docker-compose.yml
+++ b/services/jotty/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     environment:
       - NODE_ENV=production
       - TZ=${TZ}
+      - NEXTAUTH_URL=https://jotty.${NEXUS_DOMAIN}
+      - NEXTAUTH_URL_INTERNAL=http://127.0.0.1:3000
     healthcheck:
       test:
         [


### PR DESCRIPTION
### Why are you making these changes?

These errors were showing up in Jotty logs:
```
Session check error:  [TypeError: fetch failed] {
  cause:  [Error: A07341B6FFFF0000:error:0A00010B:SSL routines:ssl3_get_record:wrong version number:../deps/openssl/openssl/ssl/record/ssl3_record.c:354:
] {
  library: 'SSL routines',
  reason: 'wrong version number',
  code: 'ERR_SSL_WRONG_VERSION_NUMBER'
}
}
```