### PR TITLE
feat(backups): add ProtonDrive raw sync for paperless and booklore

### DIFF
--- a/ansible/roles/nexus/tasks/main.yml
+++ b/ansible/roles/nexus/tasks/main.yml
@@ -138,7 +138,7 @@
     name: "nexus-protondrive-sync"
     minute: "0"
     hour: "4"
-    job: "{{ nexus_root_directory }}/scripts/sync-to-protondrive.sh {{ nexus_base_path }}/Backups {{ protondrive_sync_directory }}"
+    job: "{{ nexus_root_directory }}/scripts/sync-to-protondrive.sh {{ nexus_base_path }}/Backups {{ protondrive_sync_directory }}/Containers"
   when:
     - "'backups' in nexus_final_services"
     - protondrive_sync_directory is defined
@@ -151,6 +151,48 @@
   when:
     - "'backups' in nexus_final_services"
     - protondrive_sync_directory is not defined or protondrive_sync_directory == ''
+
+# Raw user data ProtonDrive sync — paperless documents and booklore books
+# Syncs raw files directly (not via restic) so recovery is never coupled to restic.
+- name: Install ProtonDrive paperless raw sync crontab
+  ansible.builtin.cron:
+    name: "nexus-protondrive-paperless-sync"
+    minute: "0"
+    hour: "4"
+    job: "{{ nexus_root_directory }}/scripts/sync-to-protondrive.sh {{ nexus_userdata_directory }}/paperless {{ protondrive_sync_directory }}/paperless"
+  when:
+    - nexus_userdata_directory is defined
+    - nexus_userdata_directory != ''
+    - protondrive_sync_directory is defined
+    - protondrive_sync_directory != ''
+
+- name: Remove ProtonDrive paperless raw sync crontab
+  ansible.builtin.cron:
+    name: "nexus-protondrive-paperless-sync"
+    state: absent
+  when: >
+    nexus_userdata_directory is not defined or nexus_userdata_directory == '' or
+    protondrive_sync_directory is not defined or protondrive_sync_directory == ''
+
+- name: Install ProtonDrive booklore raw sync crontab
+  ansible.builtin.cron:
+    name: "nexus-protondrive-booklore-sync"
+    minute: "0"
+    hour: "4"
+    job: "{{ nexus_root_directory }}/scripts/sync-to-protondrive.sh {{ nexus_userdata_directory }}/booklore {{ protondrive_sync_directory }}/booklore"
+  when:
+    - nexus_userdata_directory is defined
+    - nexus_userdata_directory != ''
+    - protondrive_sync_directory is defined
+    - protondrive_sync_directory != ''
+
+- name: Remove ProtonDrive booklore raw sync crontab
+  ansible.builtin.cron:
+    name: "nexus-protondrive-booklore-sync"
+    state: absent
+  when: >
+    nexus_userdata_directory is not defined or nexus_userdata_directory == '' or
+    protondrive_sync_directory is not defined or protondrive_sync_directory == ''
 
 - name: Stop and remove existing containers
   ansible.builtin.shell: |

--- a/ansible/vars/vault.yml.sample
+++ b/ansible/vars/vault.yml.sample
@@ -206,10 +206,14 @@ backups_r2_bucket: "nexus-backups"
 
 # ProtonDrive sync directory (TEMPORARY - until rclone supports ProtonDrive)
 # Mount point where Proton Drive Bridge exposes your drive.
-# When set, a daily crontab rsyncs the restic repo here at 4 AM.
-# Leave empty to skip ProtonDrive sync.
+# When set, three daily crontabs run (set this to the root backup directory):
+#   4 AM — rsyncs restic repos  → protondrive_sync_directory/Containers/
+#   5 AM — rsyncs raw paperless → protondrive_sync_directory/paperless/
+#   5 AM — rsyncs raw booklore  → protondrive_sync_directory/booklore/
+# Subdirectories are created automatically on first run.
+# Leave empty to skip all ProtonDrive syncs.
 # Migration: see scripts/sync-to-protondrive.sh header for rclone migration steps.
-# Example: /Volumes/ProtonDrive/nexus-backups
+# Example: /Volumes/Backups
 protondrive_sync_directory: ""
 
 # =============================================================================

--- a/scripts/sync-to-protondrive.sh
+++ b/scripts/sync-to-protondrive.sh
@@ -2,14 +2,15 @@
 # =============================================================================
 # TEMPORARY WORKAROUND - ProtonDrive Backup via rsync
 # =============================================================================
-# Syncs the local restic backup repository to a ProtonDrive-mounted directory.
+# Rsyncs a local directory to a ProtonDrive-mounted destination.
+# Used for both restic backup repos and raw user data (paperless, booklore).
 # This is a workaround until rclone adds ProtonDrive support.
 #
 # Migration to rclone (when available):
 #   1. Add a ProtonDrive rclone remote: rclone config
-#   2. Add a third repo in services/backups/config.json.j2
-#   3. Remove protondrive_sync_directory from vault.yml
-#   4. Run deploy to remove the crontab automatically
+#   2. For restic repos: add a third repo in services/backups/config.json.j2
+#   3. For raw data: add rclone sync tasks in Ansible
+#   4. Clear protondrive_sync_directory in vault — deploy removes the crontabs
 #   5. Delete this script
 #
 # Usage: sync-to-protondrive.sh <source_dir> <dest_dir>
@@ -32,8 +33,8 @@ if [ ! -d "$SOURCE_DIR" ]; then
     exit 1
 fi
 
-if [ ! -d "$DEST_DIR" ]; then
-    log "ERROR: Destination directory does not exist: $DEST_DIR"
+if ! mkdir -p "$DEST_DIR"; then
+    log "ERROR: Could not create destination directory: $DEST_DIR"
     log "Is Proton Drive Bridge running and mounted?"
     exit 1
 fi

--- a/services/backups/README.md
+++ b/services/backups/README.md
@@ -86,23 +86,32 @@ docker compose up -d <service>
 3. Configure R2 credentials (Terraform outputs)
 4. Restore: `docker exec backrest restic -r rclone:r2:<bucket> restore latest --target /tmp/restore`
 
-> **Note:** R2 backups only contain service configs (`/base_data`), not user data. Large data (documents, books, worlds) must be restored from local backups or original sources.
+> **Note:** R2 backups only contain service configs (`/base_data`), not user data. Documents and books can be restored directly from ProtonDrive if `protondrive_sync_directory` is configured. Other large data (foundryvtt worlds, sure data) must be restored from local backups or original sources.
 
 ## ProtonDrive Sync (Temporary)
 
-> **Workaround** until [rclone adds ProtonDrive support](https://github.com/rclone/rclone/issues/5804). Once available, replace with a third rclone remote in `config.json.j2`.
+> **Workaround** until [rclone adds ProtonDrive support](https://github.com/rclone/rclone/issues/5804). Once available, replace with rclone remotes.
 
-Rsyncs the entire restic repo to a ProtonDrive-mounted directory daily at 4 AM. Uses `--delete` so ProtonDrive always has exactly one copy mirroring the local repo.
+Three daily rsyncs to a ProtonDrive-mounted directory. All use `--delete` so ProtonDrive always mirrors the source exactly.
 
-**Enable:** Set `protondrive_sync_directory` in vault (e.g., `/Volumes/ProtonDrive/nexus-backups`). The crontab is installed/removed automatically on deploy.
+| Crontab | Schedule | Source | Destination | Purpose |
+|---------|----------|--------|-------------|---------|
+| `nexus-protondrive-sync` | 4 AM | `Backups/` (restic repos) | `protondrive_sync_directory/Containers` | Restic repos mirrored to ProtonDrive |
+| `nexus-protondrive-paperless-sync` | 4 AM | `$NEXUS_USERDATA_DIRECTORY/paperless` | `protondrive_sync_directory/paperless` | Raw documents, no restic dependency |
+| `nexus-protondrive-booklore-sync` | 4 AM | `$NEXUS_USERDATA_DIRECTORY/booklore` | `protondrive_sync_directory/booklore` | Raw books, no restic dependency |
+
+The raw data syncs (paperless, booklore) mean documents and books are recoverable directly from ProtonDrive without needing restic at all.
+
+**Enable:** Set `protondrive_sync_directory` to the root backup directory (e.g. `.../ProtonDrive/Backups`) and `nexus_userdata_directory` in vault. All crontabs are installed/removed automatically on deploy. Destination subdirectories are created automatically on first run.
 
 **Migrate to rclone:**
 1. Add a ProtonDrive rclone remote (`rclone config`)
-2. Add a third repo in `config.json.j2` pointing to the rclone remote
-3. Clear `protondrive_sync_directory` in vault — deploy removes the crontab
-4. Delete `scripts/sync-to-protondrive.sh`
+2. For restic repos: add a third repo in `config.json.j2`
+3. For raw data: replace crontabs with `rclone sync` tasks in Ansible
+4. Clear `protondrive_sync_directory` in vault — deploy removes all crontabs
+5. Delete `scripts/sync-to-protondrive.sh`
 
 ## Maintenance
 
-- **Daily**: Automated backups at 2 AM (local), 3 AM (R2), 4 AM (ProtonDrive rsync if enabled)
+- **Daily**: Automated backups at 2 AM (local), 3 AM (R2), 4 AM (ProtonDrive rsync if enabled: restic repos + raw paperless/booklore)
 - **Weekly**: `nexus maintenance weekly` verifies backups exist


### PR DESCRIPTION
### Why are you making these changes?

Extends ProtonDrive sync to cover raw user data (paperless documents, booklore books) directly via rsync, independent of restic. This means documents and books are recoverable from ProtonDrive without needing restic at all. Also organizes restic repos into a `Containers/` subdirectory and auto-creates destination dirs on first run instead of erroring.

### How was this tested?

Manual review of crontab logic and script changes. Crontabs install/remove automatically based on vault variable presence, consistent with existing pattern.